### PR TITLE
Adding Plots and cli update

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ An example dataset can be found in this repository under `sample_data/`.
 To run PROTRIDER, a configuration file needs to be provided. This can be adapted from the configuration file provided in this code repo (`config.yaml`). User options include
 
 - `out_dir`: Path to the directory to store output files.
+- `input_intensities`: Csv input file containing the protein intensities.
 - `cov_used`: List of column names contained in the sample annotation file to be included as known covariates.
 - `find_q_method`: Method to determine latent space dimension of autoencoder.
 - `pval_dist`: Distribution (Gaussian or Student's t-test) for P-value calculation.
@@ -56,5 +57,13 @@ To run PROTRIDER, a configuration file needs to be provided. This can be adapted
 Run PROTRIDER using the following command: 
 
 ```
-protrider --config <config_path> --input_intensities <intensities_path> --sample_annotation <sample_anno_path>
+protrider --run_pipeline --config <config_path>
+```
+Create PROTRIDER plots using the following command:
+```
+protrider --plot_all --config <config_path>
+```
+Each plot can also be created separately, for example:
+```
+protrider --plot_aberrant_per_sample --config <config_path>
 ```

--- a/config.yaml
+++ b/config.yaml
@@ -1,7 +1,14 @@
 # path to output directory to store result files
 out_dir: output
+
+# csv input file containing intensities. Columns are samples and rows are proteins.
+input_intensities: input_intensities.csv
+
 # column name in the input file indicating the column name containing the protein names/IDs
 index_col: "protein_ID"
+
+# csv file containing sample annotations
+# sample_annotation: sample_annotation.csv
 
 ## Preprocessing params
 # maximum percentage of missing values per protein

--- a/config.yaml
+++ b/config.yaml
@@ -34,7 +34,7 @@ n_epochs: 100 # number of training epochs
 lr: 1e-4 # learning rate
 batch_size:
 
-find_q_method: "OHT" # option to find latent space dimension. Options: OHT, gs
+find_q_method: "OHT" # option to find latent space dimension. Options: OHT, gs or an integer value
 init_pca: True # PCA initialization
 h_dim: # hidden dimension, only for n_layers>1
 

--- a/protrider/main.py
+++ b/protrider/main.py
@@ -38,6 +38,7 @@ logger = logging.getLogger(__name__)
 @click.option(
     '--plot_title',
     type=str,
+    default="",
     help="Title of the plots"
 )
 @click.option(
@@ -75,7 +76,7 @@ logger = logging.getLogger(__name__)
     is_flag=True,
     help="Plot training loss, nubmer of aberrant proteins per sample, pvalue plots and endocing dimension search"
 )
-def main(config, run_pipeline: bool = False, plot_heatmap: bool = False, plot_title: str = None, plot_pvals: bool = False, 
+def main(config, run_pipeline: bool = False, plot_heatmap: bool = False, plot_title: str = "", plot_pvals: bool = False, 
          plot_encoding_dim: bool = False, plot_aberrant_per_sample: bool = False, plot_training_loss: bool = False, 
          plot_expected_vs_observed: bool = False, protein_id: str = None, plot_all: bool = False) -> None:
     """# PROTRIDER
@@ -87,6 +88,7 @@ def main(config, run_pipeline: bool = False, plot_heatmap: bool = False, plot_ti
     - Official code repository: https://github.com/gagneurlab/PROTRIDER
 
     """
+    print(plot_title)
     ## Load config with params
     config = yaml.load(open(config), Loader=yaml.FullLoader) 
     if run_pipeline is True:
@@ -108,6 +110,8 @@ def main(config, run_pipeline: bool = False, plot_heatmap: bool = False, plot_ti
         logger.info("plotting training loss")
         _plot_training_loss(config["out_dir"], plot_title)
     elif plot_expected_vs_observed is True:
+        if protein_id is None:
+            raise ValueError("protein_id is required for plot_expected_vs_observed function.")
         logger.info(f"plotting expected vs observed protein intensitiy for protein {protein_id}")
         _plot_expected_vs_observed(config["out_dir"], protein_id, plot_title)
     elif plot_all is True:
@@ -115,6 +119,8 @@ def main(config, run_pipeline: bool = False, plot_heatmap: bool = False, plot_ti
         _plot_aberrant_per_sample(config["out_dir"], plot_title)
         _plot_encoding_dim(config["out_dir"], config['find_q_method'], plot_title)
         _plot_training_loss(config["out_dir"], plot_title)
+        if protein_id is None:
+            raise ValueError("protein_id is required for plot_expected_vs_observed function.")
         _plot_expected_vs_observed(config["out_dir"], protein_id, plot_title)
 
 

--- a/protrider/main.py
+++ b/protrider/main.py
@@ -12,7 +12,7 @@ import logging
 import os
 
 from .utils import Result, ModelInfo, run_experiment, run_experiment_cv
-from .plots import _plot_pvals, _plot_encoding_dim
+from .plots import _plot_pvals, _plot_encoding_dim, _plot_aberrant_per_sample
 
 logger = logging.getLogger(__name__)
 
@@ -56,6 +56,11 @@ logger = logging.getLogger(__name__)
     help="Plot the endocing dimension search plot"
 )
 @click.option(
+    '--plot_aberrant_per_sample',
+    is_flag=True,
+    help="Plot nubmer of aberrant proteins per sample"
+)
+@click.option(
     "--sample_annotation",
     help="csv file containing sample annotations",
     type=click.Path(exists=True, dir_okay=False),
@@ -65,7 +70,7 @@ logger = logging.getLogger(__name__)
     help="Output directory to save results",
     type=click.Path(exists=False, dir_okay=True, file_okay=False),
 )
-def main(config, input_intensities: str, run_pipeline: bool = False, plot_heatmap: bool = False, plot_title: str = None, plot_pvals: bool = False, plot_encoding_dim: bool = False, sample_annotation: str = None, out_dir: str = None) -> None:
+def main(config, input_intensities: str, run_pipeline: bool = False, plot_heatmap: bool = False, plot_title: str = None, plot_pvals: bool = False, plot_encoding_dim: bool = False, plot_aberrant_per_sample: bool = False, sample_annotation: str = None, out_dir: str = None) -> None:
     """# PROTRIDER
 
     PROTRIDER is a package for calling protein outliers on mass spectrometry data
@@ -86,6 +91,9 @@ def main(config, input_intensities: str, run_pipeline: bool = False, plot_heatma
     elif plot_encoding_dim is True:
          print("plotting encoding dimension search plot")
          _plot_encoding_dim(config["out_dir"], config['find_q_method'], plot_title)
+    elif plot_aberrant_per_sample is True:
+        print("plotting number of aberrant proteins per sample")
+        _plot_aberrant_per_sample(config["out_dir"], plot_title)
     elif run_pipeline is True:
         print('Runing PROTRIDER pipeline')
         return run(config, input_intensities, sample_annotation, out_dir)

--- a/protrider/main.py
+++ b/protrider/main.py
@@ -95,8 +95,9 @@ def main(config, run_pipeline: bool = False, plot_heatmap: bool = False, plot_ti
         logger.info('Runing PROTRIDER pipeline')
         return run(config)
     elif plot_heatmap is True:
-        logger.info("plotting correlation_heatmaps")
-        os.system("Rscript ~/PROTRIDER_plot_heatmap.R " + config['sample_annotation'] + " " + config['out_dir'] + " " + plot_title)
+        # TODO add plot_heatmap
+        logger.info("plotting correlation_heatmaps is not implemented yet.")
+        return
     elif plot_pvals is True:
         logger.info("plotting pvalue plots")
         _plot_pvals(config["out_dir"], config['pval_dist'], plot_title)

--- a/protrider/main.py
+++ b/protrider/main.py
@@ -12,7 +12,7 @@ import logging
 import os
 
 from .utils import Result, ModelInfo, run_experiment, run_experiment_cv
-from .plots import _plot_pvals, _plot_encoding_dim, _plot_aberrant_per_sample, _plot_loss
+from .plots import _plot_pvals, _plot_encoding_dim, _plot_aberrant_per_sample, _plot_training_loss
 
 logger = logging.getLogger(__name__)
 
@@ -56,12 +56,12 @@ logger = logging.getLogger(__name__)
     help="Plot nubmer of aberrant proteins per sample"
 )
 @click.option(
-    '--plot_loss',
+    '--plot_training_loss',
     is_flag=True,
     help="Plot training loss history"
 )
 def main(config, run_pipeline: bool = False, plot_heatmap: bool = False, plot_title: str = None, plot_pvals: bool = False, 
-         plot_encoding_dim: bool = False, plot_aberrant_per_sample: bool = False, plot_loss: bool = False) -> None:
+         plot_encoding_dim: bool = False, plot_aberrant_per_sample: bool = False, plot_training_loss: bool = False) -> None:
     """# PROTRIDER
 
     PROTRIDER is a package for calling protein outliers on mass spectrometry data
@@ -85,9 +85,9 @@ def main(config, run_pipeline: bool = False, plot_heatmap: bool = False, plot_ti
     elif plot_aberrant_per_sample is True:
         print("plotting number of aberrant proteins per sample")
         _plot_aberrant_per_sample(config["out_dir"], plot_title)
-    elif plot_loss is True:
+    elif plot_training_loss is True:
         print("plotting training loss")
-        _plot_loss(config["out_dir"], plot_title)
+        _plot_training_loss(config["out_dir"], plot_title)
     elif run_pipeline is True:
         print('Runing PROTRIDER pipeline')
         return run(config)

--- a/protrider/model_helper.py
+++ b/protrider/model_helper.py
@@ -23,7 +23,7 @@ def find_latent_dim(dataset, method='OHT',
                     out_dir=None, device=torch.device('cpu'),
                     presence_absence=False, lambda_bce=1.
                     ):
-    if method == "OHT":
+    if method == "OHT" or method == "oht":
         logger.info('OHT method for finding latent dim')
         dataset.perform_svd()
         q = dataset.find_enc_dim_optht()
@@ -82,7 +82,7 @@ def find_latent_dim(dataset, method='OHT',
             df_gs.to_csv(out_p, header=True, index=True)
             logger.info(f"\t Saved grid_search to {out_p}")
     else:
-        print("Setting q is to the fixed user provided value of " + str(method))
+        print("Setting q is a fixed user-provided value")
         q = int(method)
     return q
 

--- a/protrider/model_helper.py
+++ b/protrider/model_helper.py
@@ -27,7 +27,7 @@ def find_latent_dim(dataset, method='OHT',
         logger.info('OHT method for finding latent dim')
         dataset.perform_svd()
         q = dataset.find_enc_dim_optht()
-    else:
+    elif method == "gs":
         logger.info('Grid search method for finding latent dim')
         logger.info('Injecting outliers')
         inj_freq = float(inj_freq)
@@ -81,7 +81,9 @@ def find_latent_dim(dataset, method='OHT',
             out_p = f'{out_dir}/grid_search.csv'
             df_gs.to_csv(out_p, header=True, index=True)
             logger.info(f"\t Saved grid_search to {out_p}")
-
+    else:
+        print("Setting q is to the fixed user provided value of " + str(method))
+        q = int(method)
     return q
 
 

--- a/protrider/model_helper.py
+++ b/protrider/model_helper.py
@@ -48,7 +48,7 @@ def find_latent_dim(dataset, method='OHT',
                         loss, mse_loss, bce_loss)
 
             logger.info('\tFitting model')
-            loss, mse_loss, bce_loss = train(injected_dataset, model, criterion, n_epochs, learning_rate, batch_size)
+            loss, mse_loss, bce_loss, _ = train(injected_dataset, model, criterion, n_epochs, learning_rate, batch_size)
             logger.info('\tFinal loss after model fit: %s, mse_loss: %s, bce_loss: %s',
                         loss, mse_loss, bce_loss)
             X_out = model(injected_dataset.X, injected_dataset.torch_mask,

--- a/protrider/plots.py
+++ b/protrider/plots.py
@@ -2,8 +2,10 @@ import numpy as np
 import pandas as pd
 import plotnine as pn
 import os
+import matplotlib.pyplot as plt
+import seaborn as sns
 
-__all__ = ["_plot_pvals", "_plot_encoding_dim", "_plot_aberrant_per_sample", "_plot_aberrant_per_sample", "_plot_loss"]
+__all__ = ["_plot_pvals", "_plot_encoding_dim", "_plot_aberrant_per_sample", "_plot_aberrant_per_sample", "_plot_training_loss", "_plot_cv_loss"]
 
 
 def _plot_pvals(output_dir, distribution, plot_title=""):
@@ -111,6 +113,7 @@ def _plot_encoding_dim(output_dir, find_q_method, plot_title="", oht_q=None):
     p_out.save(output_dir + "/plots/encoding_dim_search.png", 
                width=4, height=4, units='in', dpi=300)
 
+
 def _plot_aberrant_per_sample(output_dir, plot_title=""):
     os.makedirs(f"{output_dir}/plots/", exist_ok=True)
 
@@ -159,7 +162,8 @@ def _plot_aberrant_per_sample(output_dir, plot_title=""):
     p_out.save(output_dir + "/plots/aberrant_per_sample.png",
                width=4, height=4, units='in', dpi=300)
 
-def _plot_loss(output_dir, plot_title=""):
+
+def _plot_training_loss(output_dir, plot_title=""):
     os.makedirs(f"{output_dir}/plots/", exist_ok=True)
     fontsize = 12
     loss_histoty = pd.read_csv(f"{output_dir}/train_losses.csv")
@@ -173,3 +177,23 @@ def _plot_loss(output_dir, plot_title=""):
     # Save plot
     p_out.save(output_dir + "/plots/training_loss.png",
                width=6, height=6, units='in', dpi=300)
+
+
+def _plot_cv_loss(train_losses, val_losses, fold, out_dir):
+    # plot the loss history; stratified by fold
+    plot_dir = Path(out_dir) / 'plots'
+    plot_dir.mkdir(parents=True, exist_ok=True)
+    out_p = f'{plot_dir}/loss_history_fold{fold}.png'
+
+    df = pd.concat([pd.DataFrame(dict(type='validation', loss=val_losses, epoch=np.arange(len(val_losses)))),
+                    pd.DataFrame(dict(type='train', loss=train_losses, epoch=np.arange(len(train_losses))))])
+    sns.set(style="whitegrid")
+    plt.figure(figsize=(10, 6))
+    sns.lineplot(data=df, x='epoch', y='loss', hue='type')
+    plt.title(f'Loss history for fold {fold}')
+    plt.xlabel('Epoch')
+    plt.ylabel('Loss')
+    plt.legend(title=f'Fold {fold}')
+    plt.savefig(out_p)
+    plt.close()
+    logger.info(f"Saved loss history plot for fold {fold} to {out_p}")

--- a/protrider/plots.py
+++ b/protrider/plots.py
@@ -1,0 +1,113 @@
+import numpy as np
+import pandas as pd
+import plotnine as pn
+import os
+
+import matplotlib.pyplot as plt
+
+__all__ = ["_plot_pvals", "_plot_encoding_dim"]
+
+
+def _plot_pvals(output_dir, distribution, plot_title=""):
+    os.makedirs(output_dir + "/plots/", exist_ok=True)
+  
+    dt_pvals = pd.read_csv(os.path.join(output_dir, "pvals_one_sided.csv"))
+    dt_pvals = dt_pvals.melt(id_vars='proteinID')
+    dt_pvals = dt_pvals.dropna(subset=['value'])
+    
+    if distribution == "t":
+        dist = "Student's t-distribution"
+        p_color = "#0047ab"
+    else:
+        dist = "Normal distribution"
+        p_color = "#3cb371"
+
+    dt_pvals['type'] = dist
+   
+    fontsize = 10
+    
+    g_pvals = (
+        pn.ggplot(dt_pvals, pn.aes(x='value')) +
+        pn.geom_histogram(bins=100, boundary=0, fill=p_color) +
+        pn.theme_bw(base_size=fontsize) +
+        pn.facet_wrap('~type', ncol=1) +
+        pn.labs(
+            x='One-sided P-value',
+            y='Count',
+            title=plot_title
+        ) 
+    )
+    
+    g_pvals.save(output_dir + "/plots/pvalues_dist.png", width=4, height=4, dpi=300)
+
+    
+    pv_t = dt_pvals['value'].dropna().values
+    theoretical = -np.log10((np.arange(1, len(pv_t) + 1)) / (len(pv_t) + 1))
+    sample = -np.log10(np.sort(pv_t))
+    qq_data = pd.DataFrame({
+        'Theoretical': theoretical,
+        'Sample': sample,
+        'type': dist
+    })
+
+    g_qq = (
+        pn.ggplot(qq_data, pn.aes(x='Theoretical', y='Sample')) +
+        pn.geom_point(color=p_color) +
+        pn.geom_abline(intercept=0, slope=1, color='lightgrey', linetype='dashed') +
+        pn.labs(
+            title=plot_title,
+            x='Theoretical -log10(P-value)',
+            y='Observed -log10(P-value)'
+        ) +
+        pn.theme_bw(base_size=fontsize)
+    )
+
+    # Save QQ plot
+    g_qq.save(output_dir + "/plots/qqplots.png", width=4, height=4, dpi=300)
+
+
+def _plot_encoding_dim(output_dir, find_q_method, plot_title="", oht_q=None):
+    
+    if find_q_method != "gs":
+        print("plot_encoding_dim is not implemented for OHT yet.")
+        return
+    
+    os.makedirs(output_dir + "/plots/", exist_ok=True)
+    
+    encoding_dims = pd.read_csv(output_dir + "/grid_search.csv")
+    additional_info = pd.read_csv(output_dir + "/additional_info.csv")
+    bestQ = additional_info["q"].iloc[0]
+    best_row = encoding_dims[encoding_dims["encod_dim"] == bestQ]
+
+    p_out = (
+        pn.ggplot(encoding_dims, pn.aes("encod_dim", "aucpr")) +
+        pn.geom_point() +
+        pn.scale_x_log10() +
+        #pn.geom_smooth(method='loess') +
+        # Optimum line & label
+        pn.geom_vline(pn.aes(xintercept="encod_dim", color="'Grid search'"), 
+                   data=best_row, show_legend=True) +
+        pn.geom_text(pn.aes(x=bestQ - 0.5, y=0.0, label=str(bestQ)), data=best_row) +
+        pn.labs(x="Encoding dimensions", 
+                y="Evaluation loss (AUPRC)", 
+                color="Optimal Q", 
+                title="Search for best encoding dimension " + plot_title)
+    )
+
+    # Add OHT line/label if present
+    if oht_q is not None:
+        p_out += (
+            pn.geom_vline(aes(xintercept=oht_q, color="'OHT'"), show_legend=True) +
+            pn.geom_text(aes(x=oht_q - 0.5, y=0.0, label=str(oht_q)),
+                      data=pd.DataFrame({"x": [oht_q], "y": [0.0]})) +
+            pn.scale_color_manual(values={"Grid search": "red", "OHT": "lightblue"})
+        )
+    else:
+        p_out += pn.scale_color_manual(values={"Grid search": "red"})
+    
+    fontsize = 10
+    p_out += pn.theme_bw(base_size=fontsize)
+
+    # Save plot
+    p_out.save(output_dir + "/plots/encoding_dim_search.png", 
+               width=6, height=6, units='in', dpi=300)

--- a/protrider/plots.py
+++ b/protrider/plots.py
@@ -4,11 +4,16 @@ import plotnine as pn
 import os
 import matplotlib.pyplot as plt
 import seaborn as sns
+import logging
 
-__all__ = ["_plot_pvals", "_plot_encoding_dim", "_plot_aberrant_per_sample", "_plot_aberrant_per_sample", "_plot_training_loss", "_plot_cv_loss"]
+
+__all__ = ["_plot_pvals", "_plot_encoding_dim", "_plot_aberrant_per_sample", "_plot_aberrant_per_sample",
+           "_plot_training_loss", "_plot_cv_loss", "_plot_expected_vs_observed"]
+
+logger = logging.getLogger(__name__)
 
 
-def _plot_pvals(output_dir, distribution, plot_title=""):
+def _plot_pvals(output_dir, distribution, plot_title="", fontsize=10):
     os.makedirs(f"{output_dir}/plots/", exist_ok=True)
   
     dt_pvals = pd.read_csv(os.path.join(output_dir, "pvals_one_sided.csv"))
@@ -23,9 +28,7 @@ def _plot_pvals(output_dir, distribution, plot_title=""):
         p_color = "#3cb371"
 
     dt_pvals['type'] = dist
-   
-    fontsize = 10
-    
+
     g_pvals = (
         pn.ggplot(dt_pvals, pn.aes(x='value')) +
         pn.geom_histogram(bins=100, boundary=0, fill=p_color) +
@@ -38,9 +41,8 @@ def _plot_pvals(output_dir, distribution, plot_title=""):
         ) 
     )
     
-    g_pvals.save(output_dir + "/plots/pvalues_dist.png", width=4, height=4, dpi=300)
+    g_pvals.save(f"{output_dir}/plots/pvalues_dist.png", width=4, height=4, dpi=300)
 
-    
     pv_t = dt_pvals['value'].dropna().values
     theoretical = -np.log10((np.arange(1, len(pv_t) + 1)) / (len(pv_t) + 1))
     sample = -np.log10(np.sort(pv_t))
@@ -62,18 +64,15 @@ def _plot_pvals(output_dir, distribution, plot_title=""):
         pn.theme_bw(base_size=fontsize)
     )
 
-    # Save QQ plot
-    g_qq.save(output_dir + "/plots/qqplots.png", width=4, height=4, dpi=300)
+    g_qq.save(f"{output_dir}/plots/qqplots.png", width=4, height=4, dpi=300)
 
 
-def _plot_encoding_dim(output_dir, find_q_method, plot_title="", oht_q=None):
+def _plot_encoding_dim(output_dir, find_q_method, plot_title="", oht_q=None, fontsize=10):
     os.makedirs(f"{output_dir}/plots/", exist_ok=True)
  
     if find_q_method != "gs":
         print("plot_encoding_dim is not implemented for OHT yet.")
         return
-    
-    os.makedirs(output_dir + "/plots/", exist_ok=True)
     
     encoding_dims = pd.read_csv(output_dir + "/grid_search.csv")
     additional_info = pd.read_csv(output_dir + "/additional_info.csv")
@@ -106,15 +105,13 @@ def _plot_encoding_dim(output_dir, find_q_method, plot_title="", oht_q=None):
     else:
         p_out += pn.scale_color_manual(values={"Grid search": "red"})
     
-    fontsize = 10
     p_out += pn.theme_bw(base_size=fontsize)
 
-    # Save plot
-    p_out.save(output_dir + "/plots/encoding_dim_search.png", 
-               width=4, height=4, units='in', dpi=300)
+    p_out.save(f"{output_dir}/plots/encoding_dim_search.png",
+               width=6, height=4, units='in', dpi=300)
 
 
-def _plot_aberrant_per_sample(output_dir, plot_title=""):
+def _plot_aberrant_per_sample(output_dir, plot_title="", fontsize=10):
     os.makedirs(f"{output_dir}/plots/", exist_ok=True)
 
     res = pd.read_csv(f"{output_dir}/protrider_summary.csv")
@@ -135,7 +132,6 @@ def _plot_aberrant_per_sample(output_dir, plot_title=""):
     median_val = aberrant_numbers["outlier_count"].median()
     percentile_95 = aberrant_numbers["outlier_count"].quantile(0.95)
 
-    fontsize = 12
     yadjust = 1.2
     
     p_out = (
@@ -158,14 +154,12 @@ def _plot_aberrant_per_sample(output_dir, plot_title=""):
         pn.theme_bw(base_size=fontsize)
     )
     
-    # Save plot
-    p_out.save(output_dir + "/plots/aberrant_per_sample.png",
-               width=4, height=4, units='in', dpi=300)
+    p_out.save(f"{output_dir}/plots/aberrant_per_sample.png",
+               width=6, height=4, units='in', dpi=300)
 
 
-def _plot_training_loss(output_dir, plot_title=""):
+def _plot_training_loss(output_dir, plot_title="", fontsize=10):
     os.makedirs(f"{output_dir}/plots/", exist_ok=True)
-    fontsize = 12
     loss_histoty = pd.read_csv(f"{output_dir}/train_losses.csv")
     p_out = (
         pn.ggplot(loss_histoty, pn.aes(x="epoch", y="train_loss")) +
@@ -174,9 +168,8 @@ def _plot_training_loss(output_dir, plot_title=""):
         pn.theme_bw(base_size=fontsize)
     )
 
-    # Save plot
-    p_out.save(output_dir + "/plots/training_loss.png",
-               width=6, height=6, units='in', dpi=300)
+    p_out.save(f"{output_dir}/plots/training_loss.png",
+               width=6, height=4, units='in', dpi=300)
 
 
 def _plot_cv_loss(train_losses, val_losses, fold, out_dir):
@@ -197,3 +190,43 @@ def _plot_cv_loss(train_losses, val_losses, fold, out_dir):
     plt.savefig(out_p)
     plt.close()
     logger.info(f"Saved loss history plot for fold {fold} to {out_p}")
+
+
+def _plot_expected_vs_observed(output_dir, protein_id, plot_title="", fontsize=10):
+    os.makedirs(f"{output_dir}/plots/", exist_ok=True)
+    data_in = pd.read_csv(f"{output_dir}/processed_input.csv")
+    data_out = pd.read_csv(f"{output_dir}/output.csv")
+    summary = pd.read_csv(f"{output_dir}/protrider_summary.csv")
+
+    data_in_melted = data_in[data_in["proteinID"] == protein_id].melt(id_vars="proteinID", var_name="SAMPLE_ID", value_name="in_int")
+    data_out_melted = data_out[data_out["proteinID"] == protein_id].melt(id_vars="proteinID", var_name="SAMPLE_ID", value_name="out_int")
+
+    # Merge inputs and outputs
+    df_plot = pd.merge(data_in_melted, data_out_melted, on="SAMPLE_ID")
+    summary_filtered = summary[(summary["proteinID"] == protein_id) & (summary["PROTEIN_outlier"] == True)]
+    is_outlier = df_plot["SAMPLE_ID"].isin(summary_filtered["sampleID"])
+    df_plot["outlier"] = is_outlier.replace({True: "Outlier", False: None})
+    df_plot["label"] = df_plot["SAMPLE_ID"].where(is_outlier, None)
+    df_plot["outlier"] = pd.Categorical(df_plot["outlier"], categories=["Outlier"])
+
+    p_out = (
+        pn.ggplot(df_plot, pn.aes(x="in_int", y="out_int")) +
+        pn.geom_point(pn.aes(color="outlier"), show_legend=False) +
+        pn.geom_text(
+            pn.aes(label="label"),
+            size=4,
+            va="bottom", ha="left",
+            nudge_y=0.001  # slight vertical shift to avoid overlap
+        ) +
+        pn.scale_x_log10() +
+        pn.scale_y_log10() +
+        pn.labs(
+            x="Observed log10-intensity",
+            y="Expected log10-intensity",
+            title=f"Protein: {protein_id}"
+        ) +
+        pn.theme_bw(base_size=fontsize)
+    )
+
+    p_out.save(f"{output_dir}/plots/expected_vs_observed.png",
+               width=4, height=4, units='in', dpi=300)

--- a/protrider/plots.py
+++ b/protrider/plots.py
@@ -210,7 +210,7 @@ def _plot_expected_vs_observed(output_dir, protein_id, plot_title="", fontsize=1
     df_plot["outlier"] = pd.Categorical(df_plot["outlier"], categories=["Outlier"])
 
     p_out = (
-        pn.ggplot(df_plot, pn.aes(x="in_int", y="out_int")) +
+        pn.ggplot(df_plot, pn.aes(x="out_int", y="in_int")) +
         pn.geom_point(pn.aes(color="outlier"), show_legend=False) +
         pn.geom_text(
             pn.aes(label="label"),
@@ -221,8 +221,8 @@ def _plot_expected_vs_observed(output_dir, protein_id, plot_title="", fontsize=1
         pn.scale_x_log10() +
         pn.scale_y_log10() +
         pn.labs(
-            x="Observed log10-intensity",
-            y="Expected log10-intensity",
+            x="Expected log10-intensity",
+            y="Observed log10-intensity",
             title=f"Protein: {protein_id}"
         ) +
         pn.theme_bw(base_size=fontsize)

--- a/protrider/plots.py
+++ b/protrider/plots.py
@@ -3,11 +3,11 @@ import pandas as pd
 import plotnine as pn
 import os
 
-__all__ = ["_plot_pvals", "_plot_encoding_dim", "_plot_aberrant_per_sample", "_plot_aberrant_per_sample"]
+__all__ = ["_plot_pvals", "_plot_encoding_dim", "_plot_aberrant_per_sample", "_plot_aberrant_per_sample", "_plot_loss"]
 
 
 def _plot_pvals(output_dir, distribution, plot_title=""):
-    os.makedirs(output_dir + "/plots/", exist_ok=True)
+    os.makedirs(f"{output_dir}/plots/", exist_ok=True)
   
     dt_pvals = pd.read_csv(os.path.join(output_dir, "pvals_one_sided.csv"))
     dt_pvals = dt_pvals.melt(id_vars='proteinID')
@@ -65,7 +65,7 @@ def _plot_pvals(output_dir, distribution, plot_title=""):
 
 
 def _plot_encoding_dim(output_dir, find_q_method, plot_title="", oht_q=None):
-    os.makedirs(output_dir + "/plots/", exist_ok=True)
+    os.makedirs(f"{output_dir}/plots/", exist_ok=True)
  
     if find_q_method != "gs":
         print("plot_encoding_dim is not implemented for OHT yet.")
@@ -112,7 +112,7 @@ def _plot_encoding_dim(output_dir, find_q_method, plot_title="", oht_q=None):
                width=4, height=4, units='in', dpi=300)
 
 def _plot_aberrant_per_sample(output_dir, plot_title=""):
-    os.makedirs(output_dir + "/plots/", exist_ok=True)
+    os.makedirs(f"{output_dir}/plots/", exist_ok=True)
 
     res = pd.read_csv(f"{output_dir}/protrider_summary.csv")
     
@@ -158,3 +158,18 @@ def _plot_aberrant_per_sample(output_dir, plot_title=""):
     # Save plot
     p_out.save(output_dir + "/plots/aberrant_per_sample.png",
                width=4, height=4, units='in', dpi=300)
+
+def _plot_loss(output_dir, plot_title=""):
+    os.makedirs(f"{output_dir}/plots/", exist_ok=True)
+    fontsize = 12
+    loss_histoty = pd.read_csv(f"{output_dir}/train_losses.csv")
+    p_out = (
+        pn.ggplot(loss_histoty, pn.aes(x="epoch", y="train_loss")) +
+        pn.geom_line(color="blue") +
+        pn.labs(x="Epoch", y="Loss", title=plot_title) +
+        pn.theme_bw(base_size=fontsize)
+    )
+
+    # Save plot
+    p_out.save(output_dir + "/plots/training_loss.png",
+               width=6, height=6, units='in', dpi=300)

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,5 @@ optht
 pydeseq2
 scipy
 scikit-learn
+seaborn
+plotnine

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,8 @@ setup(
                             'scipy',
                             'scikit-learn',
                             'logging',
-                            'pathlib'
+                            'seaborn',
+                            'plotnine',
                             ],
         url='https://github.com/gagneurlab/PROTRIDER',
         license='',


### PR DESCRIPTION
This pr adds functions to plot both qc and result figures and updates the cli. Changes include:
- Now saving left-sided z-scores and training loss which are required for plots
- Moved input_intensity and sample_annotation to config instead of cli ([commit](https://github.com/gagneurlab/PROTRIDER/commit/2450ed9b716047e08fd08e3eef33839339f3c53b))
- Now encoding_dimension can also be set to a fixed value instead of using OHT or gridsearch ([commit](https://github.com/gagneurlab/PROTRIDER/commit/a2d78afde5efef26f63b12073e9f555595873cd1)).
- Adds run_pipeline, plot_heatmap, plot_title, plot_pvals, plot_pvals, plot_aberrant_per_sample, plot_training_loss, plot_expected_vs_observed, protein_id, plot_all